### PR TITLE
Support headerless PEM input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.1.4
+Current version: 0.1.5
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 
@@ -81,8 +81,8 @@ Then open `http://localhost:8080/your-debug-file.html`. From the browser console
 
 Use the `Load` menu to import data:
 
-- `Load -> from File`: opens the browser file picker for DER or PEM files.
-- `Load -> from Clipboard as PEM`: reads PEM text from the clipboard and parses it.
+- `Load -> from File`: opens the browser file picker for DER, PEM, or headerless base64 text files.
+- `Load -> from Clipboard as PEM`: reads PEM text, including headerless base64-encoded ASN.1 data, from the clipboard and parses it.
 - `Load -> from Clipboard as HEX`: reads a hexadecimal DER string from the clipboard and parses it.
 - `Close`: clears the current document and returns the viewer to the empty state.
 - `Tools -> Expand All`: opens every visible tree item in the current document.
@@ -93,7 +93,7 @@ The file picker accepts common certificate and ASN.1-related extensions, includi
 
 ## Supported Data
 
-pkistudio supports ASN.1 DER binaries, BER constructed values with indefinite length, and PEM files. PEM input is base64-decoded in the browser before parsing.
+pkistudio supports ASN.1 DER binaries, BER constructed values with indefinite length, PEM files, and headerless base64-encoded ASN.1 data. PEM and headerless base64 input are decoded in the browser before parsing.
 
 The viewer displays:
 

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.1.4';
+  const APP_VERSION = '0.1.5';
 
   const APP_STYLES = `:host {
   color-scheme: light;
@@ -893,12 +893,12 @@ details[open] > summary .node-line {
     <label id="dropZone" class="picker" for="fileInput">
       <input id="fileInput" type="file" accept=".der,.pem,.cer,.crt,.csr,.p7b,.p7c,.crl,.bin,application/pkix-cert,application/pkcs10,application/octet-stream,text/plain" />
       <strong>Select a DER / PEM file</strong>
-      <p>Open DER binaries or PEM files such as certificates, CSRs, CRLs, and PKCS#7.</p>
+      <p>Open DER binaries, PEM files, or headerless base64 ASN.1 data.</p>
       <span class="button">Open File</span>
     </label>
     <div id="viewer" class="viewer empty">No DER / PEM file selected yet.</div>
     <p id="fileNotice" class="notice">
-      PEM input is base64-decoded before parsing.
+      PEM and headerless base64 input are decoded before parsing.
     </p>
   </section>
 </main>
@@ -1320,6 +1320,14 @@ details[open] > summary .node-line {
     function isPemText(text) {
       return /-----BEGIN [^-]+-----/.test(text);
     }
+
+    function normalizeBase64Text(text) {
+      const base64 = text.replace(/\s+/g, '');
+      if (!base64 || base64.length % 4 !== 0) return '';
+      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) return '';
+      if (/=/.test(base64.slice(0, -2))) return '';
+      return base64;
+    }
     
     function base64ToBytes(base64) {
       const binary = atob(base64);
@@ -1354,10 +1362,23 @@ details[open] > summary .node-line {
       }
       return bytes;
     }
+
+    function decodeHeaderlessPem(text) {
+      const base64 = normalizeBase64Text(text);
+      if (!base64) throw new Error('Headerless PEM data must be valid base64 text');
+      const bytes = base64ToBytes(base64);
+      parseElements(bytes, 0, bytes.length);
+      return bytes;
+    }
     
     function getDerBytes(bytes) {
       const text = decodeAscii(bytes);
       if (isPemText(text)) return { bytes: decodePem(text), format: 'PEM' };
+      try {
+        return { bytes: decodeHeaderlessPem(text), format: 'headerless PEM' };
+      } catch (_) {
+        // Fall through to raw DER/BER bytes when the text is not a valid base64-encoded ASN.1 value.
+      }
       return { bytes, format: 'DER' };
     }
     
@@ -2519,7 +2540,7 @@ details[open] > summary .node-line {
       hideOctetDialog();
       viewer.classList.add('empty');
       viewer.innerHTML = 'No DER / PEM file selected yet.';
-      fileNotice.textContent = 'PEM input is base64-decoded before parsing.';
+      fileNotice.textContent = 'PEM and headerless base64 input are decoded before parsing.';
     }
     
     async function renderFile(file) {
@@ -2544,8 +2565,8 @@ details[open] > summary .node-line {
     async function loadClipboardAsPem() {
       try {
         const text = await readClipboardText();
-        if (!isPemText(text)) throw new Error('No PEM BEGIN/END block was found on the clipboard');
-        renderDerBytes(decodePem(text), 'Loaded PEM from the clipboard.');
+        const bytes = isPemText(text) ? decodePem(text) : decodeHeaderlessPem(text);
+        renderDerBytes(bytes, `Loaded ${isPemText(text) ? 'PEM' : 'headerless PEM'} from the clipboard.`);
       } catch (error) {
         fileNotice.textContent = `Could not load PEM from the clipboard: ${error.message}`;
       }


### PR DESCRIPTION
## Summary
- Accept headerless base64-encoded ASN.1 text as PEM-like input when loading files.
- Reuse the same decoder for `Load -> from Clipboard as PEM` so headerless base64 can be accepted there too when clipboard permissions allow reading.
- Update app copy, README support notes, and the app version to `0.1.5`.

## Implementation Notes
- Headerless input is only treated as PEM-like when it is valid base64 and the decoded bytes parse as ASN.1.
- Non-base64 text still falls through to the existing DER/BER error path.

## Verification
- `node --check app/static/pkistudio.js`
- `git diff --check`
- VS Code Problems check for `app/static/pkistudio.js` and `README.md`
- Browser check at `http://127.0.0.1:8080/`: loaded `MAMCAQE=` as a headerless PEM file and confirmed the SEQUENCE / INTEGER tree rendered.
- Browser check: loaded the same value with PEM BEGIN/END headers and confirmed existing PEM behavior still works.
- Browser check: invalid text still reports a parse error instead of being accepted as headerless PEM.

Note: direct `Load -> from Clipboard as PEM` browser verification was blocked by clipboard read permission in the test browser, but it uses the same headerless decoder path after clipboard text is read.

Fixes #9