### PR TITLE
Remove redundant viewer file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.2.0
+Current version: 0.2.1
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 
@@ -123,7 +123,7 @@ Then open `http://localhost:8080/your-debug-file.html`. From the browser console
 
 ## Loading Data
 
-Use the `Load` menu to import data:
+Use the `Load` menu or drop a file onto the viewer to import data:
 
 - `Load -> from File`: opens the browser file picker for DER, PEM, or headerless base64 text files.
 - `Load -> from Clipboard as PEM`: reads PEM text, including headerless base64-encoded ASN.1 data, from the clipboard and parses it.

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.2.0';
+  const VERSION = '0.2.1';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.0';
+  const APP_VERSION = '0.2.1';
 
   const APP_STYLES = `:host {
   color-scheme: light;
@@ -142,45 +142,6 @@ p {
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
 }
 
-.picker {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 4px 12px;
-  align-items: center;
-  place-items: center;
-  min-height: auto;
-  margin-bottom: 8px;
-  border: 1px solid #c9cdd3;
-  border-radius: 3px;
-  padding: 8px 10px;
-  text-align: left;
-  background: #fff;
-}
-
-.picker.dragover {
-  border-color: var(--accent);
-  background: #eef6ff;
-}
-
-.picker strong,
-.picker p {
-  justify-self: start;
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  grid-row: 1 / span 2;
-  grid-column: 2;
-  border: 1px solid #8f98a3;
-  border-radius: 3px;
-  padding: 5px 14px;
-  color: #111827;
-  background: linear-gradient(#ffffff, #e7e9ee);
-  cursor: pointer;
-}
-
 input[type="file"] {
   position: absolute;
   width: 1px;
@@ -207,6 +168,11 @@ input[type="file"] {
   place-items: center;
   padding: 32px;
   color: var(--muted);
+}
+
+.viewer.dragover {
+  border-color: var(--accent);
+  background: #eef6ff;
 }
 
 .tree {
@@ -896,12 +862,7 @@ details[open] > summary .node-line {
   </section>
 
   <section class="card">
-    <label id="dropZone" class="picker" for="fileInput">
-      <input id="fileInput" type="file" accept=".der,.pem,.cer,.crt,.csr,.p7b,.p7c,.crl,.bin,application/pkix-cert,application/pkcs10,application/octet-stream,text/plain" />
-      <strong>Select a DER / PEM file</strong>
-      <p>Open DER binaries, PEM files, or headerless base64 ASN.1 data.</p>
-      <span class="button">Open File</span>
-    </label>
+    <input id="fileInput" type="file" accept=".der,.pem,.cer,.crt,.csr,.p7b,.p7c,.crl,.bin,application/pkix-cert,application/pkcs10,application/octet-stream,text/plain" hidden />
     <div id="viewer" class="viewer empty">No DER / PEM file selected yet.</div>
     <p id="fileNotice" class="notice">
       PEM and headerless base64 input are decoded before parsing.
@@ -1099,7 +1060,6 @@ details[open] > summary .node-line {
     const mount = resolveMount(options.mount);
     const scope = createAppRoot(mount, options);
     const fileInput = scope.querySelector('#fileInput');
-    const dropZone = scope.querySelector('#dropZone');
     const menu = scope.querySelector('.menu');
     const loadMenu = scope.querySelector('#loadMenu');
     const saveMenu = scope.querySelector('#saveMenu');
@@ -3082,20 +3042,20 @@ details[open] > summary .node-line {
     });
     
     for (const eventName of ['dragenter', 'dragover']) {
-      dropZone.addEventListener(eventName, (event) => {
+      viewer.addEventListener(eventName, (event) => {
         event.preventDefault();
-        dropZone.classList.add('dragover');
+        viewer.classList.add('dragover');
       });
     }
     
     for (const eventName of ['dragleave', 'drop']) {
-      dropZone.addEventListener(eventName, (event) => {
+      viewer.addEventListener(eventName, (event) => {
         event.preventDefault();
-        dropZone.classList.remove('dragover');
+        viewer.classList.remove('dragover');
       });
     }
     
-    dropZone.addEventListener('drop', (event) => {
+    viewer.addEventListener('drop', (event) => {
       const [file] = event.dataTransfer.files;
       if (file) renderFile(file);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "main": "app/static/pkistudio-core.js",
   "exports": {


### PR DESCRIPTION
## Summary
- Remove the visible DER/PEM picker prompt and Open File button from the viewer.
- Keep Load -> from File working through the hidden file input.
- Move drag-and-drop loading onto the viewer area and bump release metadata to 0.2.1.

## Verification
- npm run check
- npm test
- Browser check at http://127.0.0.1:8080/: confirmed the picker prompt/button are gone, Load -> from File opens a file chooser, and dropping a minimal DER file onto the viewer loads it.

Fixes #15