### PR TITLE
Add node subtree byte extraction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.2.1
+Current version: 0.2.2
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 
@@ -26,15 +26,20 @@ When `#pkistudio`, `[data-pkistudio]`, or `[data-pkistudio-mount]` is present, t
 <script src="/path/to/pkistudio.js" data-pkistudio-auto-init="false" defer></script>
 <script>
 	window.addEventListener('DOMContentLoaded', () => {
-		window.PkiStudio.init({
+		const studio = window.PkiStudio.init({
 			mount: '#certificate-viewer',
 			oidUrl: '/path/to/oids.json'
 		});
+
+		// After loading data, export a visible node and its children as DER bytes.
+		// const bytes = studio.getNodeBytes('1');
 	});
 </script>
 ```
 
 By default the generated UI is isolated in a Shadow DOM so host-page styles do not need to match pkistudio's internal markup.
+
+The object returned by `window.PkiStudio.init()` exposes `loadBytes(bytes, notice)`, `getNodeBytes(nodeId)`, `close()`, `mount`, and `root`. `getNodeBytes(nodeId)` returns a `Uint8Array` containing the selected ASN.1 node and its subtree as DER bytes. Node IDs are visible in the generated tree markup as `data-node-id` attributes and match the IDs assigned by the Core API serializer for the same parsed document.
 
 ## Reusing the Core API
 
@@ -66,6 +71,7 @@ The initial Core API is intentionally read-oriented. It includes:
 - `parseAsn1(input, options)`: returns a JSON-friendly parsed summary.
 - `serializeTree(nodes, options)` and `serializeNode(node, options)`: convert parsed nodes into plain objects.
 - `encodeNodes(nodes)` and `encodeNode(node)`: re-encode parsed ASN.1 nodes.
+- `getNodeBytes(nodes, nodeId)`: re-encode a parsed node and its subtree by node ID.
 - `decodePem(text)`, `hexToBytes(text)`, `decodeOid(bytes)`, and `encodeOid(text)`: lower-level helpers.
 - `getTagName(node)`, `describeValue(node)`, `findNodeById(nodes, id)`, and `resolveOid(oid, oidNames)`: inspection helpers.
 

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.2.1';
+  const VERSION = '0.2.2';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',
@@ -567,6 +567,12 @@
     return flattenNodes(nodes).find((node) => node.id === String(nodeId)) || null;
   }
 
+  function getNodeBytes(nodes, nodeId) {
+    const node = findNodeById(nodes, nodeId);
+    if (!node) throw new Error('The node was not found');
+    return encodeNode(node);
+  }
+
   function resolveOid(oid, oidNames = {}) {
     return oidNames[oid] || '';
   }
@@ -588,6 +594,7 @@
     encodeOid,
     findNodeById,
     flattenNodes,
+    getNodeBytes,
     getNodeValueBytes,
     getTagName,
     hexToBytes,

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.1';
+  const APP_VERSION = '0.2.2';
 
   const APP_STYLES = `:host {
   color-scheme: light;
@@ -1984,6 +1984,12 @@ details[open] > summary .node-line {
       renderCurrentDocument();
     }
 
+    function getNodeBytes(nodeId) {
+      const node = nodeById.get(String(nodeId));
+      if (!node) throw new Error('The node was not found');
+      return encodeNode(node);
+    }
+
     function getCheckedValue(name) {
       return scope.querySelector(`input[name="${name}"]:checked`)?.value || '';
     }
@@ -3062,6 +3068,7 @@ details[open] > summary .node-line {
 
     return {
       close: closeDocument,
+      getNodeBytes,
       loadBytes: renderDerBytes,
       mount,
       root: scope

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "main": "app/static/pkistudio-core.js",
   "exports": {

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -13,6 +13,15 @@ test('parses and serializes a minimal DER document', () => {
   assert.deepEqual(Array.from(core.encodeNodes(document.nodes)), [0x30, 0x03, 0x02, 0x01, 0x01]);
 });
 
+test('gets DER bytes for a node subtree by id', () => {
+  const document = core.parseInput(new Uint8Array([0x30, 0x06, 0x02, 0x01, 0x01, 0x04, 0x01, 0xff]));
+  const sequenceNode = document.nodes[0];
+  const integerNode = sequenceNode.children[0];
+
+  assert.deepEqual(Array.from(core.getNodeBytes(document.nodes, sequenceNode.id)), [0x30, 0x06, 0x02, 0x01, 0x01, 0x04, 0x01, 0xff]);
+  assert.deepEqual(Array.from(core.getNodeBytes(document.nodes, integerNode.id)), [0x02, 0x01, 0x01]);
+});
+
 test('detects HEX text input in auto mode', () => {
   const summary = core.parseAsn1('3003020101');
 


### PR DESCRIPTION
## Summary
- Add `getNodeBytes(nodes, nodeId)` to the Core API for DER bytes of a parsed node subtree.
- Add `studio.getNodeBytes(nodeId)` to the viewer instance API for the currently loaded document.
- Bump release metadata to `0.2.2` and document the new API.

## Verification
- `npm test`
- `npm run check`

Fixes #17