### PR TITLE
Keep version metadata in sync

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -71,6 +71,8 @@ Derive these from the invocation when possible:
    - If `version` is known and the change is release-worthy, update version references together.
    - If `version` is pending, leave existing released version references unchanged during implementation and note the deferred version bump in the issue and PR.
    - For pkistudio version bumps, update at least:
+     - `package.json` `version`
+     - `app/static/pkistudio-core.js` `VERSION`
      - `app/static/pkistudio.js` `APP_VERSION`
      - `README.md` current version and any relevant feature documentation
    - Keep generated UI behavior consistent with the existing app style.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.2.5
+Current version: 0.2.6
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.2.2';
+  const VERSION = '0.2.6';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1,6 +1,6 @@
 (() => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.5';
+  const APP_VERSION = '0.2.6';
 
   const APP_STYLES = `:host {
   color-scheme: light dark;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "main": "app/static/pkistudio-core.js",
   "exports": {

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -1,7 +1,12 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const core = require('../app/static/pkistudio-core.js');
+const packageJson = require('../package.json');
+
+const rootDir = path.join(__dirname, '..');
 
 test('parses and serializes a minimal DER document', () => {
   const document = core.parseInput(new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x01]));
@@ -50,4 +55,15 @@ test('serializes OID comments with a supplied OID map', () => {
 
   assert.equal(serialized.value, '1.2.840.113549');
   assert.equal(serialized.oidName, 'rsadsi');
+});
+
+test('keeps public version metadata in sync', () => {
+  const viewerSource = fs.readFileSync(path.join(rootDir, 'app/static/pkistudio.js'), 'utf8');
+  const readme = fs.readFileSync(path.join(rootDir, 'README.md'), 'utf8');
+  const viewerVersion = viewerSource.match(/const APP_VERSION = '([^']+)'/)[1];
+  const readmeVersion = readme.match(/^Current version: (\S+)$/m)[1];
+
+  assert.equal(core.VERSION, packageJson.version);
+  assert.equal(viewerVersion, packageJson.version);
+  assert.equal(readmeVersion, packageJson.version);
 });


### PR DESCRIPTION
## Summary
- Bump pkistudiojs public version metadata to 0.2.6 for this patch release.
- Align Core API `VERSION` with the package, viewer, and README versions.
- Add a test that fails when public version metadata drifts.
- Update the release workflow prompt so future version bumps include Core API metadata.

## Verification
- `npm test`
- `npm run check`

Fixes #25