### PR TITLE
Prepare viewer import API for npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.2.6
+Current version: 0.3.0
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 
@@ -44,6 +44,24 @@ The bundled viewer fills the available browser content area under the top menu, 
 The viewer follows the browser or operating system light/dark theme preference. The selected node actions, dialogs, notices, tree display, and new-window views use the same effective theme.
 
 The object returned by `window.PkiStudio.init()` exposes `loadBytes(bytes, notice)`, `getNodeBytes(nodeId)`, `close()`, `mount`, and `root`. `getNodeBytes(nodeId)` returns a `Uint8Array` containing the selected ASN.1 node and its subtree as DER bytes. Node IDs are visible in the generated tree markup as `data-node-id` attributes and match the IDs assigned by the Core API serializer for the same parsed document.
+
+The viewer can also be imported from npm for browser application bundles. Importing the module is safe in Node-like module evaluation contexts, but `init()` still requires a browser DOM:
+
+```js
+const viewer = require('pkistudiojs/viewer');
+
+window.addEventListener('DOMContentLoaded', () => {
+	const studio = viewer.init({
+		mount: '#certificate-viewer',
+		oidUrl: '/path/to/oids.json',
+		newWindowUrl: '/viewer.html'
+	});
+
+	studio.loadBytes(new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x01]), 'Loaded DER.');
+});
+```
+
+`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context.
 
 ## Reusing the Core API
 

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.2.6';
+  const VERSION = '0.3.0';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1,6 +1,16 @@
-(() => {
+((root, factory) => {
+  const api = factory(root);
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root && root.document) root.PkiStudio = api;
+})(typeof globalThis !== 'undefined' ? globalThis : undefined, (root) => {
   let defaultInstance = null;
-  const APP_VERSION = '0.2.6';
+  const APP_VERSION = '0.3.0';
+
+  function requireBrowserDom() {
+    if (!root || !root.document || !root.window) {
+      throw new Error('PkiStudio viewer requires a browser DOM. Importing pkistudiojs/viewer is supported, but init() must run in a browser.');
+    }
+  }
 
   const APP_STYLES = `:host {
   color-scheme: light dark;
@@ -1346,6 +1356,7 @@ details[open] > summary .node-line {
   }
 
   function init(options = {}) {
+    requireBrowserDom();
     const mount = resolveMount(options.mount);
     const scope = createAppRoot(mount, options);
     const fileInput = scope.querySelector('#fileInput');
@@ -3486,22 +3497,30 @@ details[open] > summary .node-line {
     };
   }
 
-  window.PkiStudio = {
-    core: window.PkiStudioCore || null,
+  const api = {
+    core: root?.PkiStudioCore || null,
     init,
+    autoInit,
     version: APP_VERSION
   };
 
   function autoInit() {
-    if (defaultInstance || document.querySelector('script[data-pkistudio-auto-init="false"]')) return;
+    if (!root?.document) return null;
+    if (defaultInstance) return defaultInstance;
+    if (document.querySelector('script[data-pkistudio-auto-init="false"]')) return null;
     const mount = document.querySelector('[data-pkistudio-mount], [data-pkistudio], #pkistudio');
-    if (!mount) return;
+    if (!mount) return null;
     defaultInstance = init({ mount, fullscreen: true });
+    return defaultInstance;
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', autoInit, { once: true });
-  } else {
-    autoInit();
+  if (root?.document) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', autoInit, { once: true });
+    } else {
+      autoInit();
+    }
   }
-})();
+
+  return api;
+});

--- a/docs/npm-viewer-import-design.md
+++ b/docs/npm-viewer-import-design.md
@@ -1,0 +1,124 @@
+# npm Viewer Import Design
+
+## Goal
+
+Make `pkistudiojs/viewer` a proper npm public API for browser applications that want to embed the PkiStudioJS viewer as an internal viewer/editor.
+
+The viewer is still a browser UI component. Importing it in Node-like module evaluation contexts should be safe, but rendering and editing require a browser DOM.
+
+## Reference Consumer: pkistudio/pvkgadgets
+
+`pkistudio/pvkgadgets` currently vendors PkiStudioJS browser assets under `public/vendor/pkistudiojs/` and loads them from HTML:
+
+- `pkistudio-core.js`
+- `pkistudio.js`
+- `oids.json`
+
+The main application disables auto-init and mounts the viewer manually:
+
+```js
+viewer = window.PkiStudio.init({
+  mount: '#viewerMount',
+  oidUrl: `${APP_BASE_URL}vendor/pkistudiojs/oids.json`,
+  newWindowUrl: `${APP_BASE_URL}viewer.html`
+});
+```
+
+The standalone viewer page also initializes manually with `fullscreen: true`.
+
+## Behaviors pvkgadgets Depends On
+
+The current integration is deeper than simple display. A stable npm viewer API must preserve these behaviors:
+
+- `init(options)` returns a viewer instance.
+- The instance exposes `loadBytes(bytes, notice)` to display selected DER data.
+- The instance exposes `getNodeBytes(nodeId)` so host applications can read edited DER back from the viewer.
+- The instance exposes `close()` so the host can clear the viewer when no DER object is selected.
+- The instance exposes `root`, currently a `DocumentFragment` or `Element`, so host applications can add embedded styles and listen for internal viewer events.
+- The instance accepts `mount`, `oidUrl`, `newWindowUrl`, `shadowRoot`, and `fullscreen` options.
+- `newWindowUrl` must continue to let embedded apps send selected DER to a standalone viewer-only page.
+- Direct script-tag usage must continue to set `window.PkiStudio`.
+- `data-pkistudio-auto-init="false"` must continue to suppress browser auto-initialization.
+- Existing `data-action` and `data-node-action` attributes are used by pvkgadgets for readonly guarding, so they should be treated as integration-facing selectors or replaced with a better supported API before they change.
+
+## Current Problem
+
+`package.json` exports `./viewer` as `./app/static/pkistudio.js`, but that file is a browser script that directly references `window` and `document` at module top level.
+
+That means `require('pkistudiojs/viewer')` is misleading: consumers may expect it to be importable, but module evaluation can fail outside a browser DOM.
+
+## Proposed API
+
+CommonJS should work first because the package is currently CommonJS:
+
+```js
+const viewer = require('pkistudiojs/viewer');
+
+const instance = viewer.init({
+  mount: '#viewerMount',
+  oidUrl: '/oids.json',
+  newWindowUrl: '/viewer.html'
+});
+
+instance.loadBytes(bytes, 'Loaded DER.');
+```
+
+The exported object should include:
+
+- `version`
+- `core`
+- `init(options)`
+- `autoInit()` if auto-initialization remains externally useful
+
+The instance should include:
+
+- `mount`
+- `root`
+- `loadBytes(bytes, notice)`
+- `getNodeBytes(nodeId)`
+- `close()`
+
+## Implementation Direction
+
+Keep the existing browser asset usable by script tags, but wrap it so it is also import-safe:
+
+1. Convert `app/static/pkistudio.js` to the same UMD-style shape used by `pkistudio-core.js`.
+2. Build the API object without touching the DOM.
+3. Export the API with `module.exports` when CommonJS is available.
+4. Attach the API to `globalThis.PkiStudio` when a global object exists.
+5. Gate all `window` and `document` access behind browser runtime checks or inside `init()` / `autoInit()`.
+6. Make `init()` throw a clear error if called without a browser DOM.
+7. Run auto-init only when a browser DOM exists.
+
+This keeps the package simple and avoids a build step while making `pkistudiojs/viewer` honest as an npm export.
+
+## Follow-Up API Improvements
+
+The pvkgadgets integration currently reaches into viewer internals for readonly behavior. A better long-term API would reduce reliance on internal selectors:
+
+- `editable: boolean | (context) => boolean`
+- `setEditable(editable)` on the instance
+- `hiddenActions` or `disabledActions`
+- `onChange(callback)` for edited document bytes
+- `onNotice(callback)` for host-managed status display
+- `className` or `hostClassName` option for embedded styling
+
+These do not need to be completed in the first import-safe change, but the design should avoid blocking them.
+
+## Acceptance Criteria
+
+- `require('pkistudiojs/viewer')` succeeds in Node without a DOM.
+- `require('pkistudiojs/viewer').init()` without a DOM throws a clear browser-DOM-required error.
+- Existing script-tag usage still sets `window.PkiStudio`.
+- Existing manual browser initialization still works.
+- Existing auto-init behavior still works unless `data-pkistudio-auto-init="false"` is present.
+- `pvkgadgets` can migrate from vendored script tags to an npm dependency without losing `loadBytes`, `getNodeBytes`, `close`, `root`, `oidUrl`, `newWindowUrl`, `fullscreen`, or Shadow DOM behavior.
+- `npm test`, `npm run check`, and `npm pack --dry-run` pass.
+
+## Suggested Issue Title
+
+Make `pkistudiojs/viewer` import-safe for embedded browser applications
+
+## Suggested Issue Body
+
+Prepare `pkistudiojs/viewer` as a real npm public API for applications such as `pkistudio/pvkgadgets`, which embeds PkiStudioJS as an internal ASN.1 viewer/editor. The viewer should remain browser-only at runtime, but importing the module should be safe in Node-like module evaluation contexts. Preserve the current script-tag API and manual initialization behavior while adding tests and documentation for npm usage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "main": "app/static/pkistudio-core.js",
   "exports": {

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -5,6 +5,8 @@ const test = require('node:test');
 
 const core = require('../app/static/pkistudio-core.js');
 const packageJson = require('../package.json');
+const viewer = require('../app/static/pkistudio.js');
+const exportedViewer = require('pkistudiojs/viewer');
 
 const rootDir = path.join(__dirname, '..');
 
@@ -66,4 +68,19 @@ test('keeps public version metadata in sync', () => {
   assert.equal(core.VERSION, packageJson.version);
   assert.equal(viewerVersion, packageJson.version);
   assert.equal(readmeVersion, packageJson.version);
+});
+
+test('loads the viewer entry point without a browser DOM', () => {
+  assert.equal(exportedViewer, viewer);
+  assert.equal(typeof viewer.init, 'function');
+  assert.equal(typeof viewer.autoInit, 'function');
+  assert.equal(viewer.version, packageJson.version);
+  assert.equal(viewer.core, core);
+});
+
+test('reports a clear error when initializing the viewer without a browser DOM', () => {
+  assert.throws(
+    () => viewer.init(),
+    /PkiStudio viewer requires a browser DOM/
+  );
 });


### PR DESCRIPTION
Prepares the 0.3.0 npm release by making `pkistudiojs/viewer` safe to import from Node-like module evaluation contexts while keeping the viewer browser-only at runtime.

Changes:
- Wrap the viewer script with a CommonJS/browser global export shape.
- Keep existing script-tag `window.PkiStudio` and auto-init behavior.
- Add clear DOM-required errors for `viewer.init()` outside a browser.
- Add tests for `require('pkistudiojs/viewer')` and version metadata sync.
- Document npm viewer import usage and capture the `pvkgadgets` integration design notes.

Closes #27

Validation:
- `npm test`
- `npm run check`
- `npm pack --dry-run`
- Browser smoke check at `http://localhost:8080/`