### PR TITLE
Add OID resolver export

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.3.0
+Current version: 0.4.0
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ The viewer can also be imported from npm for browser application bundles. Import
 
 ```js
 const viewer = require('pkistudiojs/viewer');
+const oidResolver = require('pkistudiojs/oid-resolver');
 
 window.addEventListener('DOMContentLoaded', () => {
 	const studio = viewer.init({
 		mount: '#certificate-viewer',
-		oidUrl: '/path/to/oids.json',
+		oidResolver: oidResolver.create({
+			'1.2.3.4.5': 'Example Custom Extension'
+		}),
 		newWindowUrl: '/viewer.html'
 	});
 
@@ -61,7 +64,21 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context.
+`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. When neither option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
+
+`pkistudiojs/oid-resolver` exports a small resolver for the bundled OID dictionary:
+
+```js
+const oidResolver = require('pkistudiojs/oid-resolver');
+
+console.log(oidResolver.resolve('1.2.840.113549'));
+
+const resolver = oidResolver.create({
+	'1.2.3.4.5': 'Example Custom Extension'
+});
+```
+
+Pass the resolver to `viewer.init({ oidResolver: resolver })` or to Core serializers with `serializeTree(nodes, { oidResolver: resolver })` when application-specific OIDs should be displayed by name.
 
 ## Reusing the Core API
 
@@ -95,9 +112,9 @@ The initial Core API is intentionally read-oriented. It includes:
 - `encodeNodes(nodes)` and `encodeNode(node)`: re-encode parsed ASN.1 nodes.
 - `getNodeBytes(nodes, nodeId)`: re-encode a parsed node and its subtree by node ID.
 - `decodePem(text)`, `hexToBytes(text)`, `decodeOid(bytes)`, and `encodeOid(text)`: lower-level helpers.
-- `getTagName(node)`, `describeValue(node)`, `findNodeById(nodes, id)`, and `resolveOid(oid, oidNames)`: inspection helpers.
+- `getTagName(node)`, `describeValue(node)`, `findNodeById(nodes, id)`, and `resolveOid(oid, oidNamesOrResolver)`: inspection helpers.
 
-Use `options.format` when the input should not be auto-detected. Supported values are `auto`, `der`, `ber`, `pem`, `base64`, `headerless-pem`, and `hex`. `serializeTree` accepts options such as `maxDepth`, `includeRawValue`, `includeHexPreview`, `hexPreviewLength`, and `oidNames`.
+Use `options.format` when the input should not be auto-detected. Supported values are `auto`, `der`, `ber`, `pem`, `base64`, `headerless-pem`, and `hex`. `serializeTree` accepts options such as `maxDepth`, `includeRawValue`, `includeHexPreview`, `hexPreviewLength`, `oidNames`, and `oidResolver`.
 
 Run the local checks with:
 

--- a/app/static/oid-resolver.js
+++ b/app/static/oid-resolver.js
@@ -1,0 +1,43 @@
+((root, factory) => {
+  let bundledNames = {};
+  if (typeof module === 'object' && module.exports) {
+    bundledNames = require('./oids.json');
+  } else if (root?.PkiStudioOidNames) {
+    bundledNames = root.PkiStudioOidNames;
+  }
+
+  const api = factory(bundledNames);
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.PkiStudioOidResolver = api;
+})(typeof globalThis !== 'undefined' ? globalThis : undefined, (bundledNames) => {
+  function normalizeNames(names) {
+    if (!names) return {};
+    if (typeof names !== 'object' || Array.isArray(names)) {
+      throw new Error('OID names must be an object keyed by dotted OID strings');
+    }
+    return names;
+  }
+
+  function create(extraNames = {}, options = {}) {
+    const baseNames = normalizeNames(options.baseNames || bundledNames);
+    const names = Object.freeze({ ...baseNames, ...normalizeNames(extraNames) });
+
+    return Object.freeze({
+      names,
+      resolve(oid) {
+        return names[String(oid)] || '';
+      },
+      create(nextNames = {}) {
+        return create(nextNames, { baseNames: names });
+      }
+    });
+  }
+
+  const defaultResolver = create();
+
+  return Object.freeze({
+    names: defaultResolver.names,
+    resolve: defaultResolver.resolve,
+    create
+  });
+});

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -503,9 +503,15 @@
     };
   }
 
+  function resolveOid(oid, oidNames = {}) {
+    if (typeof oidNames === 'function') return oidNames(oid) || '';
+    if (typeof oidNames?.resolve === 'function') return oidNames.resolve(oid) || '';
+    return oidNames[oid] || '';
+  }
+
   function getOidComment(node, oidNames = {}) {
     if (node.tagClass !== 0 || node.tagNumber !== 6) return '';
-    return oidNames[describeValue(node)] || '';
+    return resolveOid(describeValue(node), oidNames);
   }
 
   function serializeNode(node, options = {}, depth = 0) {
@@ -529,7 +535,7 @@
       value: describeValue(node)
     };
 
-    const oidComment = getOidComment(node, options.oidNames);
+    const oidComment = getOidComment(node, options.oidResolver || options.oidNames);
     if (oidComment) serialized.oidName = oidComment;
     if (options.includeHexPreview !== false && !node.constructed && valueBytes.length > 0) serialized.hexPreview = toCompactHex(valueBytes, options.hexPreviewLength || 72);
     if (options.includeRawValue) serialized.valueHex = toLowerHexString(valueBytes);
@@ -571,10 +577,6 @@
     const node = findNodeById(nodes, nodeId);
     if (!node) throw new Error('The node was not found');
     return encodeNode(node);
-  }
-
-  function resolveOid(oid, oidNames = {}) {
-    return oidNames[oid] || '';
   }
 
   return {

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.3.0';
+  const VERSION = '0.4.0';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -1433,6 +1433,7 @@ details[open] > summary .node-line {
     const ITEM_TEXT_LIMIT = 250;
     const DER_CONTENT_HEX_LIMIT = 4096;
     let oidNames = {};
+    let oidResolver = normalizeOidResolver(options.oidResolver || options.oidNames);
     let currentBytes = null;
     let currentNodes = [];
     let nodeById = new Map();
@@ -1445,12 +1446,29 @@ details[open] > summary .node-line {
     let activeClipboardInsertNodeId = null;
     let activeClipboardInsertMode = 'insert-before';
     let nextNodeId = 1;
+
+    function normalizeOidResolver(source) {
+      if (!source) return null;
+      if (typeof source === 'function') return { resolve: source };
+      if (typeof source.resolve === 'function') return source;
+      if (typeof source === 'object' && !Array.isArray(source)) {
+        return { resolve: (oid) => source[oid] || '' };
+      }
+      throw new Error('oidResolver must be a resolver, function, or object keyed by dotted OID strings');
+    }
+
+    function resolveOidName(oid) {
+      if (oidResolver) return oidResolver.resolve(oid) || '';
+      return oidNames[oid] || '';
+    }
     
     async function loadOidNames() {
+      if (oidResolver) return;
       try {
         const response = await fetch(options.oidUrl || 'oids.json', { cache: 'no-cache' });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         oidNames = await response.json();
+        oidResolver = normalizeOidResolver(oidNames);
         if (currentNodes.length > 0) renderCurrentDocument();
       } catch (error) {
         console.warn('OID names could not be loaded.', error);
@@ -1983,7 +2001,7 @@ details[open] > summary .node-line {
     
     function getOidComment(node) {
       if (node.tagClass !== 0 || node.tagNumber !== 6) return '';
-      return oidNames[describeValue(node)] || '';
+      return resolveOidName(describeValue(node));
     }
     
     function describeValue(node) {

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -4,7 +4,7 @@
   if (root && root.document) root.PkiStudio = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, (root) => {
   let defaultInstance = null;
-  const APP_VERSION = '0.3.0';
+  const APP_VERSION = '0.4.0';
 
   function requireBrowserDom() {
     if (!root || !root.document || !root.window) {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "exports": {
     ".": "./app/static/pkistudio-core.js",
     "./core": "./app/static/pkistudio-core.js",
+    "./oid-resolver": "./app/static/oid-resolver.js",
     "./viewer": "./app/static/pkistudio.js"
   },
   "files": [
     "app/static/index.html",
+    "app/static/oid-resolver.js",
     "app/static/oids.json",
     "app/static/pkistudio-core.js",
     "app/static/pkistudio.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "main": "app/static/pkistudio-core.js",
   "exports": {

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -7,6 +7,7 @@ const core = require('../app/static/pkistudio-core.js');
 const packageJson = require('../package.json');
 const viewer = require('../app/static/pkistudio.js');
 const exportedViewer = require('pkistudiojs/viewer');
+const oidResolver = require('pkistudiojs/oid-resolver');
 
 const rootDir = path.join(__dirname, '..');
 
@@ -57,6 +58,29 @@ test('serializes OID comments with a supplied OID map', () => {
 
   assert.equal(serialized.value, '1.2.840.113549');
   assert.equal(serialized.oidName, 'rsadsi');
+});
+
+test('serializes OID comments with a supplied OID resolver', () => {
+  const oidBytes = core.encodeOid('1.2.3.4.5');
+  const oidNode = core.parseInput(new Uint8Array([0x06, oidBytes.length, ...oidBytes])).nodes[0];
+  const resolver = oidResolver.create({ '1.2.3.4.5': 'custom test oid' });
+  const serialized = core.serializeNode(oidNode, { oidResolver: resolver });
+
+  assert.equal(serialized.value, '1.2.3.4.5');
+  assert.equal(serialized.oidName, 'custom test oid');
+});
+
+test('exports an OID resolver with bundled names and custom overrides', () => {
+  assert.equal(oidResolver.resolve('1.2.840.113549'), 'RSA Data Security inc.,');
+
+  const resolver = oidResolver.create({
+    '1.2.840.113549': 'custom rsadsi',
+    '1.2.3.4.5': 'custom oid'
+  });
+
+  assert.equal(resolver.resolve('1.2.840.113549'), 'custom rsadsi');
+  assert.equal(resolver.resolve('1.2.3.4.5'), 'custom oid');
+  assert.equal(resolver.resolve('1.2.3.4.6'), '');
 });
 
 test('keeps public version metadata in sync', () => {


### PR DESCRIPTION
## Summary
- add `pkistudiojs/oid-resolver` as a public package export backed by the bundled OID dictionary
- let Core serializers and `viewer.init()` accept resolver-based OID lookup while preserving `oidNames` and `oidUrl` behavior
- document resolver usage and add tests for bundled lookup, custom overrides, and Core serialization

## Verification
- `npm test`
- `npm run check`
- `npm pack --dry-run`

Fixes #29