### PR TITLE
Fix new-window viewer URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.4.0
+Current version: 0.4.1
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 
@@ -64,7 +64,7 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. When neither option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
+`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. Use `newWindowUrl` when embedded applications should open selected DER in a standalone viewer page. When neither OID option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
 
 `pkistudiojs/oid-resolver` exports a small resolver for the bundled OID dictionary:
 

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.4.0';
+  const VERSION = '0.4.1';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -4,7 +4,7 @@
   if (root && root.document) root.PkiStudio = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, (root) => {
   let defaultInstance = null;
-  const APP_VERSION = '0.4.0';
+  const APP_VERSION = '0.4.1';
 
   function requireBrowserDom() {
     if (!root || !root.document || !root.window) {
@@ -2432,7 +2432,7 @@ details[open] > summary .node-line {
         return;
       }
     
-      const url = new URL(window.location.href);
+      const url = createNewWindowUrl();
       url.searchParams.set('expand', key);
       url.searchParams.set('theme', getEffectiveTheme());
       url.hash = '';
@@ -2462,7 +2462,7 @@ details[open] > summary .node-line {
         return;
       }
     
-      const url = new URL(window.location.href);
+      const url = createNewWindowUrl();
       url.searchParams.delete('expand');
       url.searchParams.set('subtree', key);
       url.searchParams.set('theme', getEffectiveTheme());
@@ -2480,6 +2480,10 @@ details[open] > summary .node-line {
 
     function openViewerWindow(url) {
       return window.open(url.toString(), '_blank');
+    }
+
+    function createNewWindowUrl() {
+      return new URL(options.newWindowUrl || window.location.href, window.location.href);
     }
     
     async function writeClipboardText(text) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkistudiojs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "repository": {
     "type": "git",

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -102,6 +102,16 @@ test('loads the viewer entry point without a browser DOM', () => {
   assert.equal(viewer.core, core);
 });
 
+test('uses the configured new-window viewer URL when opening selected nodes', () => {
+  const viewerSource = fs.readFileSync(path.join(rootDir, 'app/static/pkistudio.js'), 'utf8');
+
+  assert.match(
+    viewerSource,
+    /function createNewWindowUrl\(\) \{\s+return new URL\(options\.newWindowUrl \|\| window\.location\.href, window\.location\.href\);\s+\}/
+  );
+  assert.equal(viewerSource.match(/createNewWindowUrl\(\)/g).length, 3);
+});
+
 test('reports a clear error when initializing the viewer without a browser DOM', () => {
   assert.throws(
     () => viewer.init(),


### PR DESCRIPTION
## Summary
- Use the documented `newWindowUrl` option when opening selected DER in a new viewer window.
- Keep the existing current-page fallback when `newWindowUrl` is not configured.
- Bump package and viewer metadata to `0.4.1` for the patch release.
- Document `newWindowUrl` in the viewer init options prose and add focused regression coverage.

## Verification
- `npm test`
- `npm run check`
- `npm pack --dry-run`

Fixes #31