### PR TITLE
Publish npm package under scoped name

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -26,7 +26,7 @@ The release version may be omitted or set to `TBD` when development should proce
 
 - This prompt is a workflow guide only and does not grant repository permissions.
 - Push, tag, release, merge, and secret-backed Actions operations are possible only for users or tokens with the required repository permissions.
-- npm publication requires npm package ownership or a configured npm Trusted Publisher for `pkistudio/pkistudiojs` and `.github/workflows/publish-npm.yml`.
+- npm publication requires npm package ownership or a configured npm Trusted Publisher for `@pkistudio/pkistudiojs` and `.github/workflows/publish-npm.yml`.
 - Work in the current repository only.
 - Check the current branch, remote, and working tree before making changes.
 - Never discard uncommitted user changes.
@@ -53,7 +53,7 @@ Derive these from the invocation when possible:
    - Run a clean working tree check.
    - Confirm the current default branch and remote.
    - If `version` is known, check existing tags so the requested release version does not already exist.
-   - If `version` is known, check whether `pkistudiojs@<version>` is already published on npm so reruns do not attempt to publish an immutable version twice.
+   - If `version` is known, check whether `@pkistudio/pkistudiojs@<version>` is already published on npm so reruns do not attempt to publish an immutable version twice.
    - If `version` is pending, record that the final version must be chosen before version bumps, tagging, or release publication.
 
 2. Create Issue
@@ -123,7 +123,7 @@ Derive these from the invocation when possible:
     - Create an annotated tag `vX.Y.Z` on the merged `main` commit.
     - Push the tag.
       - The `Publish npm package` workflow runs on `v*` tag pushes and publishes with npm Trusted Publishing. It expects:
-         - npm package name: `pkistudiojs`
+         - npm package name: `@pkistudio/pkistudiojs`
          - GitHub owner/repository: `pkistudio/pkistudiojs`
          - workflow filename: `publish-npm.yml`
          - npm Trusted Publishing environment: none / blank, unless the workflow is later changed to use one.
@@ -131,7 +131,7 @@ Derive these from the invocation when possible:
       - If the version was already published manually, do not rerun the publish job for the same tag/version; npm versions are immutable and the rerun will fail.
     - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes and referencing the issue.
     - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
-      - After publication, verify `npm view pkistudiojs@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
+      - After publication, verify `npm view @pkistudio/pkistudiojs@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and import the package entry points.
 
 11. Confirm Final State
     - Verify:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.4.1
+Current version: 0.4.2
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ The object returned by `window.PkiStudio.init()` exposes `loadBytes(bytes, notic
 
 The viewer can also be imported from npm for browser application bundles. Importing the module is safe in Node-like module evaluation contexts, but `init()` still requires a browser DOM:
 
+```sh
+npm install @pkistudio/pkistudiojs
+```
+
 ```js
-const viewer = require('pkistudiojs/viewer');
-const oidResolver = require('pkistudiojs/oid-resolver');
+const viewer = require('@pkistudio/pkistudiojs/viewer');
+const oidResolver = require('@pkistudio/pkistudiojs/oid-resolver');
 
 window.addEventListener('DOMContentLoaded', () => {
 	const studio = viewer.init({
@@ -64,12 +68,12 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-`pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. Use `newWindowUrl` when embedded applications should open selected DER in a standalone viewer page. When neither OID option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
+`@pkistudio/pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. Use `newWindowUrl` when embedded applications should open selected DER in a standalone viewer page. When neither OID option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
 
-`pkistudiojs/oid-resolver` exports a small resolver for the bundled OID dictionary:
+`@pkistudio/pkistudiojs/oid-resolver` exports a small resolver for the bundled OID dictionary:
 
 ```js
-const oidResolver = require('pkistudiojs/oid-resolver');
+const oidResolver = require('@pkistudio/pkistudiojs/oid-resolver');
 
 console.log(oidResolver.resolve('1.2.840.113549'));
 
@@ -82,10 +86,10 @@ Pass the resolver to `viewer.init({ oidResolver: resolver })` or to Core seriali
 
 ## Reusing the Core API
 
-PkiStudioJS also ships a small Core API for code that needs ASN.1 parsing without mounting the browser UI. The package entry point and `pkistudiojs/core` export both resolve to `app/static/pkistudio-core.js`:
+PkiStudioJS also ships a small Core API for code that needs ASN.1 parsing without mounting the browser UI. The package entry point and `@pkistudio/pkistudiojs/core` export both resolve to `app/static/pkistudio-core.js`:
 
 ```js
-const pkistudio = require('pkistudiojs');
+const pkistudio = require('@pkistudio/pkistudiojs');
 
 const document = pkistudio.parseInput(
 	new Uint8Array([0x30, 0x03, 0x02, 0x01, 0x01])

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.4.1';
+  const VERSION = '0.4.2';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -4,7 +4,7 @@
   if (root && root.document) root.PkiStudio = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, (root) => {
   let defaultInstance = null;
-  const APP_VERSION = '0.4.1';
+  const APP_VERSION = '0.4.2';
 
   function requireBrowserDom() {
     if (!root || !root.document || !root.window) {

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -8,7 +8,7 @@
 
   function requireBrowserDom() {
     if (!root || !root.document || !root.window) {
-      throw new Error('PkiStudio viewer requires a browser DOM. Importing pkistudiojs/viewer is supported, but init() must run in a browser.');
+      throw new Error('PkiStudio viewer requires a browser DOM. Importing @pkistudio/pkistudiojs/viewer is supported, but init() must run in a browser.');
     }
   }
 

--- a/docs/npm-viewer-import-design.md
+++ b/docs/npm-viewer-import-design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Make `pkistudiojs/viewer` a proper npm public API for browser applications that want to embed the PkiStudioJS viewer as an internal viewer/editor.
+Make `@pkistudio/pkistudiojs/viewer` a proper npm public API for browser applications that want to embed the PkiStudioJS viewer as an internal viewer/editor.
 
 The viewer is still a browser UI component. Importing it in Node-like module evaluation contexts should be safe, but rendering and editing require a browser DOM.
 
@@ -45,14 +45,14 @@ The current integration is deeper than simple display. A stable npm viewer API m
 
 `package.json` exports `./viewer` as `./app/static/pkistudio.js`, but that file is a browser script that directly references `window` and `document` at module top level.
 
-That means `require('pkistudiojs/viewer')` is misleading: consumers may expect it to be importable, but module evaluation can fail outside a browser DOM.
+That means `require('@pkistudio/pkistudiojs/viewer')` is misleading if module evaluation can fail outside a browser DOM.
 
 ## Proposed API
 
 CommonJS should work first because the package is currently CommonJS:
 
 ```js
-const viewer = require('pkistudiojs/viewer');
+const viewer = require('@pkistudio/pkistudiojs/viewer');
 
 const instance = viewer.init({
   mount: '#viewerMount',
@@ -90,7 +90,7 @@ Keep the existing browser asset usable by script tags, but wrap it so it is also
 6. Make `init()` throw a clear error if called without a browser DOM.
 7. Run auto-init only when a browser DOM exists.
 
-This keeps the package simple and avoids a build step while making `pkistudiojs/viewer` honest as an npm export.
+This keeps the package simple and avoids a build step while making `@pkistudio/pkistudiojs/viewer` honest as an npm export.
 
 ## Follow-Up API Improvements
 
@@ -107,8 +107,8 @@ These do not need to be completed in the first import-safe change, but the desig
 
 ## Acceptance Criteria
 
-- `require('pkistudiojs/viewer')` succeeds in Node without a DOM.
-- `require('pkistudiojs/viewer').init()` without a DOM throws a clear browser-DOM-required error.
+- `require('@pkistudio/pkistudiojs/viewer')` succeeds in Node without a DOM.
+- `require('@pkistudio/pkistudiojs/viewer').init()` without a DOM throws a clear browser-DOM-required error.
 - Existing script-tag usage still sets `window.PkiStudio`.
 - Existing manual browser initialization still works.
 - Existing auto-init behavior still works unless `data-pkistudio-auto-init="false"` is present.
@@ -117,8 +117,8 @@ These do not need to be completed in the first import-safe change, but the desig
 
 ## Suggested Issue Title
 
-Make `pkistudiojs/viewer` import-safe for embedded browser applications
+Make `@pkistudio/pkistudiojs/viewer` import-safe for embedded browser applications
 
 ## Suggested Issue Body
 
-Prepare `pkistudiojs/viewer` as a real npm public API for applications such as `pkistudio/pvkgadgets`, which embeds PkiStudioJS as an internal ASN.1 viewer/editor. The viewer should remain browser-only at runtime, but importing the module should be safe in Node-like module evaluation contexts. Preserve the current script-tag API and manual initialization behavior while adding tests and documentation for npm usage.
+Prepare `@pkistudio/pkistudiojs/viewer` as a real npm public API for applications such as `pkistudio/pvkgadgets`, which embeds PkiStudioJS as an internal ASN.1 viewer/editor. The viewer should remain browser-only at runtime, but importing the module should be safe in Node-like module evaluation contexts. Preserve the current script-tag API and manual initialization behavior while adding tests and documentation for npm usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pkistudio/pkistudiojs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiojs",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "pkistudiojs",
-  "version": "0.4.0",
+  "name": "@pkistudio/pkistudiojs",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pkistudiojs",
-      "version": "0.4.0",
+      "name": "@pkistudio/pkistudiojs",
+      "version": "0.4.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiojs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pkistudiojs",
+  "name": "@pkistudio/pkistudiojs",
   "version": "0.4.1",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "repository": {

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -6,8 +6,8 @@ const test = require('node:test');
 const core = require('../app/static/pkistudio-core.js');
 const packageJson = require('../package.json');
 const viewer = require('../app/static/pkistudio.js');
-const exportedViewer = require('pkistudiojs/viewer');
-const oidResolver = require('pkistudiojs/oid-resolver');
+const exportedViewer = require('@pkistudio/pkistudiojs/viewer');
+const oidResolver = require('@pkistudio/pkistudiojs/oid-resolver');
 
 const rootDir = path.join(__dirname, '..');
 


### PR DESCRIPTION
Prepares the first npm publication under the scoped package name `@pkistudio/pkistudiojs`, so the package aligns with the GitHub organization and avoids ambiguity around the unscoped name.

Summary:
- Rename the npm package metadata to `@pkistudio/pkistudiojs`.
- Update README install/import examples and self-reference tests to use the scoped package name.
- Bump release metadata to `0.4.2` so the npm publication can use a new tag after this PR merges.
- Update release workflow guidance and npm verification commands for the scoped package.

Release notes draft:
PkiStudioJS 0.4.2 prepares the initial npm package publication under the scoped package name `@pkistudio/pkistudiojs`. Consumers should install and import PkiStudioJS with the scoped package name, for example `npm install @pkistudio/pkistudiojs` and `require('@pkistudio/pkistudiojs/viewer')`.

Verification:
- `npm test`
- `npm run check`
- `npm pack --dry-run`
- `git tag --list 'v0.4.2'` returned no existing tag.
- `npm view @pkistudio/pkistudiojs@0.4.2 version --json` returned 404 before publication, as expected for a new package version.

Closes #34