### PR TITLE
Add read-only viewer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The bundled viewer fills the available browser content area under the top menu, 
 
 The viewer follows the browser or operating system light/dark theme preference. The selected node actions, dialogs, notices, tree display, and new-window views use the same effective theme.
 
-The object returned by `window.PkiStudio.init()` exposes `loadBytes(bytes, notice)`, `getNodeBytes(nodeId)`, `close()`, `mount`, and `root`. `getNodeBytes(nodeId)` returns a `Uint8Array` containing the selected ASN.1 node and its subtree as DER bytes. Node IDs are visible in the generated tree markup as `data-node-id` attributes and match the IDs assigned by the Core API serializer for the same parsed document.
+The object returned by `window.PkiStudio.init()` exposes `loadBytes(bytes, notice)`, `getNodeBytes(nodeId)`, `setEditable(editable)`, `close()`, `mount`, and `root`. `getNodeBytes(nodeId)` returns a `Uint8Array` containing the selected ASN.1 node and its subtree as DER bytes. Node IDs are visible in the generated tree markup as `data-node-id` attributes and match the IDs assigned by the Core API serializer for the same parsed document.
 
 The viewer can also be imported from npm for browser application bundles. Importing the module is safe in Node-like module evaluation contexts, but `init()` still requires a browser DOM:
 
@@ -68,7 +68,7 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-`@pkistudio/pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. Use `newWindowUrl` when embedded applications should open selected DER in a standalone viewer page. When neither OID option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
+`@pkistudio/pkistudiojs/viewer` exports `version`, `core`, `init(options)`, and `autoInit()`. The `core` property points to the loaded Core API when `pkistudio-core.js` has already been loaded in the same global context. `init(options)` accepts `oidResolver` or `oidNames` when the host application wants to use the bundled OID dictionary with custom additions or overrides. Use `newWindowUrl` when embedded applications should open selected DER in a standalone viewer page. Pass `editable: false` to initialize the viewer in read-only mode; the returned instance can later switch modes with `setEditable(false)` or `setEditable(true)`. When neither OID option is supplied, the viewer keeps the existing behavior of fetching `options.oidUrl || 'oids.json'`.
 
 `@pkistudio/pkistudiojs/oid-resolver` exports a small resolver for the bundled OID dictionary:
 

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -291,11 +291,16 @@ main {
   cursor: pointer;
 }
 
-.menu button:hover,
-.menu button:focus-visible {
+.menu button:not(:disabled):hover,
+.menu button:not(:disabled):focus-visible {
   outline: none;
   border-color: var(--hover-border);
   background: var(--hover-bg);
+}
+
+.menu button:disabled {
+  color: var(--disabled-text);
+  cursor: not-allowed;
 }
 
 .menu-group {
@@ -730,11 +735,22 @@ details[open] > summary .node-line {
   display: block;
 }
 
-.node-context-menu button:hover,
-.node-context-menu button:focus-visible {
+.context-menu-group:has(.context-submenu-trigger:disabled):hover .node-context-submenu,
+.context-menu-group:has(.context-submenu-trigger:disabled):focus-within .node-context-submenu,
+.context-menu-group:has(.context-submenu-trigger:disabled).submenu-open .node-context-submenu {
+  display: none;
+}
+
+.node-context-menu button:not(:disabled):hover,
+.node-context-menu button:not(:disabled):focus-visible {
   outline: none;
   border-color: var(--hover-border);
   background: var(--hover-bg);
+}
+
+.node-context-menu button:disabled {
+  color: var(--disabled-text);
+  cursor: not-allowed;
 }
 
 .edit-dialog {
@@ -1078,17 +1094,17 @@ details[open] > summary .node-line {
       </div>
     </div>
     <div class="menu-group">
-      <button type="button" data-action="toggle-save-menu" aria-haspopup="menu" aria-expanded="false">Save</button>
+      <button type="button" data-action="toggle-save-menu" aria-haspopup="menu" aria-expanded="false" disabled>Save</button>
       <div id="saveMenu" class="submenu" role="menu" hidden>
-        <button type="button" role="menuitem" data-action="save-der-file">to File as DER</button>
+        <button type="button" role="menuitem" data-action="save-der-file" disabled>to File as DER</button>
       </div>
     </div>
-    <button type="button" data-action="close">Close</button>
+    <button type="button" data-action="close" disabled>Close</button>
     <div class="menu-group">
       <button type="button" data-action="toggle-tools-menu" aria-haspopup="menu" aria-expanded="false">Tools</button>
       <div id="toolsMenu" class="submenu" role="menu" hidden>
-        <button type="button" role="menuitem" data-action="expand-all">Expand All</button>
-        <button type="button" role="menuitem" data-action="collapse-all">Collapse All</button>
+        <button type="button" role="menuitem" data-action="expand-all" disabled>Expand All</button>
+        <button type="button" role="menuitem" data-action="collapse-all" disabled>Collapse All</button>
       </div>
     </div>
     <button type="button" data-action="about">About</button>
@@ -1434,6 +1450,7 @@ details[open] > summary .node-line {
     const DER_CONTENT_HEX_LIMIT = 4096;
     let oidNames = {};
     let oidResolver = normalizeOidResolver(options.oidResolver || options.oidNames);
+    let editable = options.editable !== false;
     let currentBytes = null;
     let currentNodes = [];
     let nodeById = new Map();
@@ -2296,11 +2313,13 @@ details[open] > summary .node-line {
       if (currentNodes.length === 0) {
         viewer.classList.add('empty');
         viewer.innerHTML = 'All nodes have been deleted.';
+        updateDocumentActionControls();
         return;
       }
     
       viewer.classList.remove('empty');
       viewer.innerHTML = `<div class="tree">${currentNodes.map((node) => renderNode(node)).join('')}</div>`;
+      updateDocumentActionControls();
     }
     
     function rebuildDocumentFromModel() {
@@ -2538,6 +2557,11 @@ details[open] > summary .node-line {
     }
 
     async function saveCurrentDerAsFile() {
+      if (!editable) {
+        fileNotice.textContent = 'This viewer is read-only.';
+        return;
+      }
+
       if (!currentBytes) {
         fileNotice.textContent = 'Load DER, PEM, or headerless base64 data before saving.';
         return;
@@ -2725,6 +2749,24 @@ details[open] > summary .node-line {
         group.querySelector('.context-submenu-trigger')?.setAttribute('aria-expanded', String(open));
       }
     }
+
+    function setNodeActionDisabled(action, disabled) {
+      const button = nodeContextMenu.querySelector(`[data-node-action="${action}"]`);
+      if (button) button.disabled = disabled;
+    }
+
+    function updateNodeContextActionControls(node) {
+      const editingDisabled = !editable;
+      setNodeActionDisabled('insert-before', editingDisabled);
+      setNodeActionDisabled('insert-before-new-item', editingDisabled);
+      setNodeActionDisabled('insert-before-clipboard-hex', editingDisabled);
+      setNodeActionDisabled('add-child', editingDisabled || !node?.constructed);
+      setNodeActionDisabled('add-child-new-item', editingDisabled || !node?.constructed);
+      setNodeActionDisabled('add-child-clipboard-hex', editingDisabled || !node?.constructed);
+      setNodeActionDisabled('delete', editingDisabled);
+
+      if (editingDisabled) setContextSubmenuOpen(null);
+    }
     
     function setRadioValue(name, value) {
       for (const input of scope.querySelectorAll(`input[name="${name}"]`)) {
@@ -2796,11 +2838,11 @@ details[open] > summary .node-line {
 
     function setDerDialogCreateMode(createMode) {
       for (const input of derForm.querySelectorAll('input[name="derClass"], input[name="derMethod"]')) {
-        input.disabled = !createMode;
+        input.disabled = !createMode || !editable;
       }
 
-      derIndex.readOnly = !createMode;
-      derHex.readOnly = !createMode;
+      derIndex.readOnly = !createMode || !editable;
+      derHex.readOnly = !createMode || !editable;
       derForm.querySelector('[data-der-action="edit-content"]').hidden = createMode;
       derIndefinite.disabled = true;
     }
@@ -2840,12 +2882,12 @@ details[open] > summary .node-line {
       derTitle.textContent = 'Edit DER';
       derIndex.value = node.tagNumber;
       derIndefinite.checked = Boolean(node.indefinite);
-      derIndefinite.disabled = !node.constructed;
+      derIndefinite.disabled = !editable || !node.constructed;
       derLength.value = formatLengthText(node);
       derTagName.textContent = tagName;
       derValuePreview.textContent = describeValue(node);
       derHex.value = toCompactHex(valueBytes, DER_CONTENT_HEX_LIMIT);
-      editButton.disabled = !isEditableNode(node);
+      editButton.disabled = !editable || !isEditableNode(node);
       editButton.title = editButton.disabled ? `${tagName} cannot be edited in detail yet` : '';
       setRadioValue('derClass', node.tagClass);
       setRadioValue('derMethod', node.constructed ? 'constructed' : 'primitive');
@@ -2854,6 +2896,7 @@ details[open] > summary .node-line {
     }
 
     function showCreateDerDialog(mode, node) {
+      if (!editable) return;
       activeDerMode = mode;
       activeDerNodeId = node.id;
       setDerDialogCreateMode(true);
@@ -2962,6 +3005,7 @@ details[open] > summary .node-line {
       extractedButton.hidden = !(node?.encapsulated && node.children.length > 0);
       activeContextNodeId = nodeId;
       setContextSubmenuOpen(null);
+      updateNodeContextActionControls(node);
       nodeContextMenu.classList.remove('open-left');
       nodeContextMenu.hidden = false;
     
@@ -2987,6 +3031,7 @@ details[open] > summary .node-line {
       viewer.classList.add('empty');
       viewer.innerHTML = 'No DER / PEM file selected yet.';
       fileNotice.textContent = 'PEM and headerless base64 input are decoded before parsing.';
+      updateDocumentActionControls();
     }
     
     async function renderFile(file) {
@@ -3004,6 +3049,7 @@ details[open] > summary .node-line {
         hideTimeDialog();
         hideOctetDialog();
         hideClipboardInsertDialog();
+        updateDocumentActionControls();
         viewer.classList.remove('empty');
         viewer.innerHTML = `<div class="error"><strong>Could not parse as DER.</strong><br>${escapeHtml(error.message)}</div>`;
       }
@@ -3095,9 +3141,43 @@ details[open] > summary .node-line {
       hideSaveMenu();
       hideToolsMenu();
     }
+
+    function updateDocumentActionControls() {
+      const disabled = currentBytes === null;
+      const saveButton = menu.querySelector('[data-action="toggle-save-menu"]');
+      const saveDerButton = menu.querySelector('[data-action="save-der-file"]');
+      const closeButton = menu.querySelector('[data-action="close"]');
+      const expandAllButton = menu.querySelector('[data-action="expand-all"]');
+      const collapseAllButton = menu.querySelector('[data-action="collapse-all"]');
+
+      for (const button of [saveButton, saveDerButton]) {
+        if (button) button.disabled = disabled || !editable;
+      }
+
+      for (const button of [closeButton, expandAllButton, collapseAllButton]) {
+        if (button) button.disabled = disabled;
+      }
+
+      if (disabled || !editable) hideSaveMenu();
+    }
+
+    function setEditable(nextEditable) {
+      editable = Boolean(nextEditable);
+      updateDocumentActionControls();
+      updateNodeContextActionControls(nodeById.get(activeContextNodeId));
+
+      if (!editable) {
+        hideDerDialog();
+        hideEditDialog();
+        hideTimeDialog();
+        hideOctetDialog();
+        hideClipboardInsertDialog();
+      }
+    }
     
     function toggleTopMenu(buttonAction, submenu) {
       const button = menu.querySelector(`[data-action="${buttonAction}"]`);
+      if (button?.disabled) return;
       const willOpen = submenu.hidden;
       hideTopMenus();
       submenu.hidden = !willOpen;
@@ -3108,6 +3188,7 @@ details[open] > summary .node-line {
     menu.addEventListener('click', async (event) => {
       const button = event.target.closest('button[data-action]');
       if (!button) return;
+      if (button.disabled) return;
     
       if (button.dataset.action === 'toggle-load-menu') {
         toggleTopMenu('toggle-load-menu', loadMenu);
@@ -3169,6 +3250,7 @@ details[open] > summary .node-line {
     nodeContextMenu.addEventListener('click', async (event) => {
       const button = event.target.closest('button[data-node-action]');
       if (!button) return;
+      if (button.disabled) return;
     
       if (button.classList.contains('context-submenu-trigger')) {
         event.preventDefault();
@@ -3236,6 +3318,11 @@ details[open] > summary .node-line {
     
     derForm.addEventListener('submit', (event) => {
       event.preventDefault();
+      if (!editable) {
+        hideDerDialog();
+        return;
+      }
+
       if (activeDerMode === 'insert-before' || activeDerMode === 'add-child') {
         try {
           const targetNodeId = activeDerNodeId;
@@ -3515,7 +3602,8 @@ details[open] > summary .node-line {
       getNodeBytes,
       loadBytes: renderDerBytes,
       mount,
-      root: scope
+      root: scope,
+      setEditable
     };
   }
 

--- a/docs/npm-viewer-import-design.md
+++ b/docs/npm-viewer-import-design.md
@@ -33,9 +33,10 @@ The current integration is deeper than simple display. A stable npm viewer API m
 - `init(options)` returns a viewer instance.
 - The instance exposes `loadBytes(bytes, notice)` to display selected DER data.
 - The instance exposes `getNodeBytes(nodeId)` so host applications can read edited DER back from the viewer.
+- The instance exposes `setEditable(editable)` so host applications can switch between editable and read-only viewer modes.
 - The instance exposes `close()` so the host can clear the viewer when no DER object is selected.
 - The instance exposes `root`, currently a `DocumentFragment` or `Element`, so host applications can add embedded styles and listen for internal viewer events.
-- The instance accepts `mount`, `oidUrl`, `newWindowUrl`, `shadowRoot`, and `fullscreen` options.
+- The instance accepts `mount`, `oidUrl`, `newWindowUrl`, `shadowRoot`, `fullscreen`, and `editable` options.
 - `newWindowUrl` must continue to let embedded apps send selected DER to a standalone viewer-only page.
 - Direct script-tag usage must continue to set `window.PkiStudio`.
 - `data-pkistudio-auto-init="false"` must continue to suppress browser auto-initialization.
@@ -94,10 +95,9 @@ This keeps the package simple and avoids a build step while making `@pkistudio/p
 
 ## Follow-Up API Improvements
 
-The pvkgadgets integration currently reaches into viewer internals for readonly behavior. A better long-term API would reduce reliance on internal selectors:
+The viewer now supports a first-class `editable` option and `setEditable(editable)` method. Further long-term API improvements could reduce other reliance on internal selectors:
 
 - `editable: boolean | (context) => boolean`
-- `setEditable(editable)` on the instance
 - `hiddenActions` or `disabledActions`
 - `onChange(callback)` for edited document bytes
 - `onNotice(callback)` for host-managed status display
@@ -112,7 +112,7 @@ These do not need to be completed in the first import-safe change, but the desig
 - Existing script-tag usage still sets `window.PkiStudio`.
 - Existing manual browser initialization still works.
 - Existing auto-init behavior still works unless `data-pkistudio-auto-init="false"` is present.
-- `pvkgadgets` can migrate from vendored script tags to an npm dependency without losing `loadBytes`, `getNodeBytes`, `close`, `root`, `oidUrl`, `newWindowUrl`, `fullscreen`, or Shadow DOM behavior.
+- `pvkgadgets` can migrate from vendored script tags to an npm dependency without losing `loadBytes`, `getNodeBytes`, `setEditable`, `close`, `root`, `oidUrl`, `newWindowUrl`, `fullscreen`, `editable`, or Shadow DOM behavior.
 - `npm test`, `npm run check`, and `npm pack --dry-run` pass.
 
 ## Suggested Issue Title

--- a/test/core-api.test.js
+++ b/test/core-api.test.js
@@ -102,6 +102,17 @@ test('loads the viewer entry point without a browser DOM', () => {
   assert.equal(viewer.core, core);
 });
 
+test('documents editable viewer mode controls', () => {
+  const viewerSource = fs.readFileSync(path.join(rootDir, 'app/static/pkistudio.js'), 'utf8');
+  const readme = fs.readFileSync(path.join(rootDir, 'README.md'), 'utf8');
+
+  assert.match(viewerSource, /let editable = options\.editable !== false;/);
+  assert.match(viewerSource, /function setEditable\(nextEditable\) \{/);
+  assert.match(viewerSource, /root: scope,\s+setEditable/);
+  assert.match(readme, /editable: false/);
+  assert.match(readme, /setEditable\(false\)/);
+});
+
 test('uses the configured new-window viewer URL when opening selected nodes', () => {
   const viewerSource = fs.readFileSync(path.join(rootDir, 'app/static/pkistudio.js'), 'utf8');
 
@@ -110,6 +121,18 @@ test('uses the configured new-window viewer URL when opening selected nodes', ()
     /function createNewWindowUrl\(\) \{\s+return new URL\(options\.newWindowUrl \|\| window\.location\.href, window\.location\.href\);\s+\}/
   );
   assert.equal(viewerSource.match(/createNewWindowUrl\(\)/g).length, 3);
+});
+
+test('disables document actions until data is loaded', () => {
+  const viewerSource = fs.readFileSync(path.join(rootDir, 'app/static/pkistudio.js'), 'utf8');
+
+  assert.match(viewerSource, /data-action="toggle-save-menu"[^>]* disabled>Save/);
+  assert.match(viewerSource, /data-action="save-der-file"[^>]* disabled>to File as DER/);
+  assert.match(viewerSource, /data-action="close" disabled>Close/);
+  assert.match(viewerSource, /data-action="toggle-tools-menu"[^>]*>Tools/);
+  assert.match(viewerSource, /data-action="expand-all"[^>]* disabled>Expand All/);
+  assert.match(viewerSource, /data-action="collapse-all"[^>]* disabled>Collapse All/);
+  assert.match(viewerSource, /function updateDocumentActionControls\(\) \{\s+const disabled = currentBytes === null;/);
 });
 
 test('reports a clear error when initializing the viewer without a browser DOM', () => {


### PR DESCRIPTION
Adds an official read-only mode for embedded viewer consumers so they no longer need to guard editing behavior by reaching into internal menu selectors.

Summary:
- Add `editable: false` support to `viewer.init(options)` and expose `setEditable(editable)` on the viewer instance.
- Disable document-mutating actions in read-only mode, including Save, Insert before, Add, Delete, DER content editing, and indefinite length changes.
- Keep read-only-safe actions available, including Load, Close, Tools, Expand All, Collapse All, Send to, and copy actions.
- Preserve document-state disabled behavior for Save, Close, Expand All, and Collapse All before data is loaded.
- Document the official API in the README and viewer import design notes.

Release notes draft:
PkiStudioJS adds an official read-only viewer mode for embedded applications. Consumers can initialize the viewer with `editable: false` or toggle it later with `setEditable(false)`, avoiding direct manipulation of internal menu selectors.

Verification:
- `npm run check`
- `npm test`
- `npm pack --dry-run`
- Browser check: `editable: false` keeps Save, Insert, Add, Delete, and Edit content disabled while leaving Close, Tools, Expand/Collapse, Send to, and copy actions available.
- Browser check: `setEditable(true)` enables mutable actions, then `setEditable(false)` disables them again.

Closes #36