### PR TITLE
Add Git LFS to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "pkistudiojs",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {}
   },
   "forwardPorts": [8080],
   "portsAttributes": {


### PR DESCRIPTION
Adds the official Dev Containers Git LFS feature so `git-lfs` is installed when the development container is rebuilt.

Verification:
- Parsed `.devcontainer/devcontainer.json` with Node to confirm it remains valid JSON.