### PR TITLE
Add ripgrep devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git-lfs:1": {}
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
   },
   "forwardPorts": [8080],
   "portsAttributes": {


### PR DESCRIPTION
## Summary
- Add the `ghcr.io/devcontainers-extra/features/ripgrep:1` devcontainer feature so Codespaces/devcontainers provide `rg`
- Keep the existing Node Bookworm image and existing GitHub CLI/Git LFS features
- No package version change because this only affects the development container environment and does not change published package artifacts or runtime behavior

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json', 'utf8')); console.log('devcontainer.json OK')"`
- `npx --yes @devcontainers/cli features info manifest ghcr.io/devcontainers-extra/features/ripgrep:1 --output-format json | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>{const j=JSON.parse(s); const meta=JSON.parse(j.manifest.annotations["dev.containers.metadata"]); if(meta.id !== "ripgrep") throw new Error("unexpected feature id "+meta.id); console.log(meta.id + " " + meta.version + " OK");})'`
- `npx --yes @devcontainers/cli read-configuration --workspace-folder . --include-features-configuration --include-merged-configuration --log-level info`
- `git diff --check -- .devcontainer/devcontainer.json`
- `npm test`
- `npm run check`

Note: a full devcontainer image build was not run in this current container because Docker CLI is not available here.