### PR TITLE
Add workflow to publish release posts to WordPress

### DIFF
--- a/.github/workflows/publish-release-to-wordpress.yml
+++ b/.github/workflows/publish-release-to-wordpress.yml
@@ -1,0 +1,71 @@
+name: Publish release to WordPress
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish release post to WordPress
+        env:
+          WPCOM_ACCESS_TOKEN: ${{ secrets.WPCOM_ACCESS_TOKEN }}
+          WPCOM_SITE_ID: ${{ secrets.WPCOM_SITE_ID }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          python3 <<'PY'
+          import os
+          import json
+          import html
+          import urllib.request
+
+          token = os.environ["WPCOM_ACCESS_TOKEN"]
+          site_id = os.environ["WPCOM_SITE_ID"]
+
+          tag = os.environ["RELEASE_TAG"]
+          name = os.environ.get("RELEASE_NAME") or tag
+          url = os.environ["RELEASE_URL"]
+          body = os.environ.get("RELEASE_BODY") or ""
+          published_at = os.environ.get("RELEASE_PUBLISHED_AT") or ""
+
+          title = f"pkistudiojs {tag} をリリースしました"
+
+          content = f"""
+          <p><strong>pkistudiojs の新しいリリースを公開しました。</strong></p>
+
+          <ul>
+            <li>リリース名: {html.escape(name)}</li>
+            <li>タグ: <code>{html.escape(tag)}</code></li>
+            <li>公開日時: {html.escape(published_at)}</li>
+            <li><a href="{html.escape(url)}">GitHub Release を見る</a></li>
+          </ul>
+
+          <h3>リリースノート</h3>
+          <pre>{html.escape(body.strip() or "詳細はGitHub Releaseを参照してください。")}</pre>
+          """
+
+          payload = {
+              "title": title,
+              "content": content,
+              "status": "draft"
+          }
+
+          req = urllib.request.Request(
+              f"https://public-api.wordpress.com/wp/v2/sites/{site_id}/posts",
+              data=json.dumps(payload).encode("utf-8"),
+              method="POST"
+          )
+          req.add_header("Authorization", f"Bearer {token}")
+          req.add_header("Content-Type", "application/json")
+
+          with urllib.request.urlopen(req) as res:
+              result = json.loads(res.read().decode("utf-8"))
+
+          print("Created:", result.get("link"))
+          PY


### PR DESCRIPTION
Adds a GitHub Actions workflow for publishing release posts to WordPress.

This is needed because `main` is protected and the local commit cannot be pushed directly; the change is submitted through a pull request instead.