### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/.github/workflows/publish-release-to-wordpress.yml
+++ b/.github/workflows/publish-release-to-wordpress.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           WPCOM_ACCESS_TOKEN: ${{ secrets.WPCOM_ACCESS_TOKEN }}
           WPCOM_SITE_ID: ${{ secrets.WPCOM_SITE_ID }}
+          WP_RELEASE_CATEGORY_ID: ${{ vars.WP_RELEASE_CATEGORY_ID }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_NAME: ${{ github.event.release.name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
@@ -21,8 +22,10 @@ jobs:
         run: |
           python3 <<'PY'
           import os
+          import re
           import json
           import html
+          import urllib.parse
           import urllib.request
 
           token = os.environ["WPCOM_ACCESS_TOKEN"]
@@ -33,8 +36,32 @@ jobs:
           url = os.environ["RELEASE_URL"]
           body = os.environ.get("RELEASE_BODY") or ""
           published_at = os.environ.get("RELEASE_PUBLISHED_AT") or ""
+          category_id = os.environ.get("WP_RELEASE_CATEGORY_ID") or ""
+
+          def make_slug(text):
+              text = text.lower()
+              text = re.sub(r"[^a-z0-9]+", "-", text)
+              return text.strip("-")
+
+          def wp_request(method, path, payload=None):
+              api_url = f"https://public-api.wordpress.com/wp/v2/sites/{site_id}{path}"
+
+              data = None
+              if payload is not None:
+                  data = json.dumps(payload).encode("utf-8")
+
+              req = urllib.request.Request(api_url, data=data, method=method)
+              req.add_header("Authorization", f"Bearer {token}")
+              req.add_header("Content-Type", "application/json")
+
+              with urllib.request.urlopen(req) as res:
+                  return json.loads(res.read().decode("utf-8"))
+
+          slug = make_slug(f"pkistudiojs-{tag}")
 
           title = f"pkistudiojs {tag} をリリースしました"
+
+          release_body = body.strip() or "詳細はGitHub Releaseを参照してください。"
 
           content = f"""
           <p><strong>pkistudiojs の新しいリリースを公開しました。</strong></p>
@@ -47,25 +74,32 @@ jobs:
           </ul>
 
           <h3>リリースノート</h3>
-          <pre>{html.escape(body.strip() or "詳細はGitHub Releaseを参照してください。")}</pre>
+          <pre>{html.escape(release_body)}</pre>
           """
 
           payload = {
               "title": title,
+              "slug": slug,
               "content": content,
-              "status": "draft"
+              "excerpt": f"pkistudiojs {tag} のリリース情報です。",
+              "status": "publish"
           }
 
-          req = urllib.request.Request(
-              f"https://public-api.wordpress.com/wp/v2/sites/{site_id}/posts",
-              data=json.dumps(payload).encode("utf-8"),
-              method="POST"
-          )
-          req.add_header("Authorization", f"Bearer {token}")
-          req.add_header("Content-Type", "application/json")
+          if category_id:
+              payload["categories"] = [int(category_id)]
 
-          with urllib.request.urlopen(req) as res:
-              result = json.loads(res.read().decode("utf-8"))
+          query = urllib.parse.urlencode({
+              "slug": slug,
+              "status": "publish,draft,pending,private,future"
+          }, safe=",")
 
-          print("Created:", result.get("link"))
+          existing = wp_request("GET", f"/posts?{query}")
+
+          if existing:
+              post_id = existing[0]["id"]
+              result = wp_request("POST", f"/posts/{post_id}", payload)
+              print("Updated:", result.get("link"))
+          else:
+              result = wp_request("POST", "/posts", payload)
+              print("Created:", result.get("link"))
           PY

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PkiStudioJS is a simplified JavaScript version of PkiStudio. It is a browser-bas
 
 A hosted version is available at https://pkistudio.github.io/pkistudiojs/.
 
-Current version: 0.6.0
+Current version: 0.6.1
 
 File contents are not uploaded to the server. The Node.js service only serves the static web application.
 

--- a/app/static/pkistudio-core.js
+++ b/app/static/pkistudio-core.js
@@ -3,7 +3,7 @@
   if (typeof module === 'object' && module.exports) module.exports = api;
   if (root) root.PkiStudioCore = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, () => {
-  const VERSION = '0.6.0';
+  const VERSION = '0.6.1';
   const CLASS_NAMES = ['Universal', 'Application', 'Context-specific', 'Private'];
   const UNIVERSAL_TAGS = {
     1: 'BOOLEAN',

--- a/app/static/pkistudio.js
+++ b/app/static/pkistudio.js
@@ -4,7 +4,7 @@
   if (root && root.document) root.PkiStudio = api;
 })(typeof globalThis !== 'undefined' ? globalThis : undefined, (root) => {
   let defaultInstance = null;
-  const APP_VERSION = '0.6.0';
+  const APP_VERSION = '0.6.1';
 
   function requireBrowserDom() {
     if (!root || !root.document || !root.window) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pkistudio/pkistudiojs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiojs",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiojs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Browser ASN.1 DER/BER/PEM viewer and reusable Core API.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary:
- Bump package and runtime version metadata to 0.6.1.
- Include the release blog-post workflow improvements for publishing/updating WordPress release posts.

Release notes draft:
- Added the release flow update that publishes release notes to WordPress and updates an existing release post when one already exists.
- Added optional WordPress release category support for release posts.

Verification:
- `npm test`
- `npm run check`
- `npm pack --dry-run`

Closes #44